### PR TITLE
Add padding to fix ui being hidden

### DIFF
--- a/Sources/tokamak-todo-example/main.swift
+++ b/Sources/tokamak-todo-example/main.swift
@@ -37,6 +37,8 @@ struct ContentView: View {
         }
       }
     }
+    .padding(.top, 70)
+    .padding(.horizontal, 40)
   }
 }
 


### PR DESCRIPTION
Just adding a little fix to move the ui down a bit from the edge. On Safari it was on on the edge and was not fully visiable.

<img width="546" alt="Screenshot 2020-11-08 at 18 42 25" src="https://user-images.githubusercontent.com/31965092/98481446-2c104c80-21f2-11eb-9c7d-ec32b450b6e8.png">

<img width="540" alt="Screenshot 2020-11-08 at 18 41 47" src="https://user-images.githubusercontent.com/31965092/98481448-2e72a680-21f2-11eb-9d31-e6ad46461fe4.png">
